### PR TITLE
Make AirMapStatus accessible from Objective-C

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -14,12 +14,12 @@ PODS:
   - AFNetworking/Serialization (3.1.0)
   - AFNetworking/UIKit (3.1.0):
     - AFNetworking/NSURLSession
-  - AirMapSDK (1.0.1):
-    - AirMapSDK/Core (= 1.0.1)
-    - AirMapSDK/Telemetry (= 1.0.1)
-    - AirMapSDK/Traffic (= 1.0.1)
-    - AirMapSDK/UI (= 1.0.1)
-  - AirMapSDK/Core (1.0.1):
+  - AirMapSDK (1.0.2):
+    - AirMapSDK/Core (= 1.0.2)
+    - AirMapSDK/Telemetry (= 1.0.2)
+    - AirMapSDK/Traffic (= 1.0.2)
+    - AirMapSDK/UI (= 1.0.2)
+  - AirMapSDK/Core (1.0.2):
     - Alamofire
     - JWTDecode
     - Log
@@ -28,15 +28,15 @@ PODS:
     - RxSwift
     - RxSwiftExt
     - SimpleKeychain
-  - AirMapSDK/Telemetry (1.0.1):
+  - AirMapSDK/Telemetry (1.0.2):
     - AirMapSDK/Core
     - CocoaAsyncSocket (~> 7.6.0)
     - CryptoSwift
     - ProtocolBuffers-Swift (~> 3.0.1)
-  - AirMapSDK/Traffic (1.0.1):
+  - AirMapSDK/Traffic (1.0.2):
     - AirMapSDK/Core
     - SwiftMQTT
-  - AirMapSDK/UI (1.0.1):
+  - AirMapSDK/UI (1.0.2):
     - AirMapSDK/Core
     - libPhoneNumber-iOS
     - Lock (< 2.0.0)
@@ -118,11 +118,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   AirMapSDK:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
-  AirMapSDK: 873cbf73337ce02fcc865b0da806d5940a738d7c
+  AirMapSDK: a80468c4750c680a51fa88f32f2d4fd55d7db3c4
   Alamofire: dc44b1600b800eb63da6a19039a0083d62a6a62d
   CocoaAsyncSocket: b9d5589f07baf9de8f34cc25abd4fcba28f13805
   CryptoSwift: f21ea03ed3a94e79d241648ce26652cd4810508a

--- a/Source/Core/Models/Permits/AirMapAvailablePermit.swift
+++ b/Source/Core/Models/Permits/AirMapAvailablePermit.swift
@@ -8,7 +8,7 @@
 
 import ObjectMapper
 
-public class AirMapAvailablePermit: Hashable, Equatable {
+public class AirMapAvailablePermit: NSObject {
 
 	public internal(set) var id = ""
 	public fileprivate(set) var name = ""
@@ -20,7 +20,7 @@ public class AirMapAvailablePermit: Hashable, Equatable {
 	public internal(set) var customProperties = [AirMapPilotPermitCustomProperty]()
 	public internal(set) var organizationId = ""
 	
-	internal init() {}
+	internal override init() {}
 	public required init?(map: Map) {}
 	
 	fileprivate static let validityFormatter: DateComponentsFormatter = {
@@ -37,7 +37,7 @@ public class AirMapAvailablePermit: Hashable, Equatable {
 		return AirMapAvailablePermit.validityFormatter.string(from: TimeInterval(minutes * 60))
 	}
 	
-	public var hashValue: Int {
+	public override var hashValue: Int {
 		return id.hashValue
 	}
 }

--- a/Source/Core/Models/Permits/AirMapPilotPermit.swift
+++ b/Source/Core/Models/Permits/AirMapPilotPermit.swift
@@ -8,7 +8,7 @@
 
 import ObjectMapper
 
-public class AirMapPilotPermit: Hashable, Equatable {
+public class AirMapPilotPermit: NSObject {
 
 	public enum PermitStatus: String {
 		case accepted
@@ -27,11 +27,11 @@ public class AirMapPilotPermit: Hashable, Equatable {
 	public var permitDetails: AirMapPilotPermitShortDetails!
 	public var organization: AirMapOrganization?
 
-	public init() {}
+	public override init() {}
 	
 	public required init?(map: Map) {}
 	
-	public var hashValue: Int {
+	public override var hashValue: Int {
 		return id.isEmpty ? permitId.hashValue : id.hashValue
 	}
 	

--- a/Source/Core/Models/Status/AirMapOrganization.swift
+++ b/Source/Core/Models/Status/AirMapOrganization.swift
@@ -8,14 +8,14 @@
 
 import ObjectMapper
 
-open class AirMapOrganization: Hashable, Equatable {
+open class AirMapOrganization: NSObject {
 
 	open fileprivate(set) var id: String!
 	open fileprivate(set) var name: String = ""
 	
 	public required init?(map: Map) {}
 	
-	open var hashValue: Int {
+	open override var hashValue: Int {
 		return id.hashValue
 	}
 }

--- a/Source/Core/Models/Status/AirMapStatus.swift
+++ b/Source/Core/Models/Status/AirMapStatus.swift
@@ -36,6 +36,43 @@ open class AirMapStatus : NSObject {
 			}
 		}
 	}
+	
+	@objc public enum IntStatusColor: Int, RawRepresentable {
+		case red
+		case yellow
+		case green
+		case gray
+		
+		public typealias RawValue = String
+
+		public var rawValue: RawValue {
+			switch self {
+				case .red:
+					return StatusColor.red.rawValue
+				case .yellow:
+					return StatusColor.yellow.rawValue
+				case .green:
+					return StatusColor.green.rawValue
+				case .gray:
+					return StatusColor.gray.rawValue;
+			}
+		}
+		
+		public init?(rawValue: RawValue) {
+			switch rawValue {
+				case "red":
+					self = .red
+				case "yellow":
+					self = .yellow
+				case "green":
+					self = .green
+				case "gray":
+					self = .gray
+				default:
+					self = .gray
+			}
+		}
+	}
 
 	public fileprivate(set) var maxSafeDistance: Meters = 0
 	public fileprivate(set) var advisoryColor = StatusColor.gray
@@ -63,6 +100,10 @@ open class AirMapStatus : NSObject {
             .flatMap { $0.requirements?.notice }
             .count > 0
     }
+	
+	public var color: IntStatusColor {
+		return IntStatusColor(rawValue: advisoryColor.rawValue)!
+	}
 	
 	internal var availablePermits: [AirMapAvailablePermit] {
 		return Array(Set(advisories.flatMap { $0.availablePermits }))

--- a/Source/Core/Models/Status/AirMapStatus.swift
+++ b/Source/Core/Models/Status/AirMapStatus.swift
@@ -37,7 +37,7 @@ open class AirMapStatus : NSObject {
 		}
 	}
 	
-	@objc public enum IntStatusColor: Int, RawRepresentable {
+	@objc public enum AirMapStatusColor: Int, RawRepresentable {
 		case red
 		case yellow
 		case green
@@ -101,8 +101,8 @@ open class AirMapStatus : NSObject {
             .count > 0
     }
 	
-	public var color: IntStatusColor {
-		return IntStatusColor(rawValue: advisoryColor.rawValue)!
+	public var color: AirMapStatusColor {
+		return AirMapStatusColor(rawValue: advisoryColor.rawValue)!
 	}
 	
 	internal var availablePermits: [AirMapAvailablePermit] {

--- a/Source/Core/Models/Status/AirMapStatus.swift
+++ b/Source/Core/Models/Status/AirMapStatus.swift
@@ -9,7 +9,8 @@
 import ObjectMapper
 
 /// A list of all airspace objects intersecting with the proposed area. Includes status color and distance.
-open class AirMapStatus {
+@objc
+open class AirMapStatus : NSObject {
 
 	public enum StatusColor: String {
 		case red

--- a/Source/Core/Models/Status/AirMapStatusAdvisory.swift
+++ b/Source/Core/Models/Status/AirMapStatusAdvisory.swift
@@ -8,7 +8,7 @@
 
 import ObjectMapper
 
-open class AirMapStatusAdvisory: Hashable, Equatable {
+open class AirMapStatusAdvisory: NSObject {
 
 	open fileprivate(set) var id: String!
 	open fileprivate(set) var name: String = ""
@@ -42,11 +42,11 @@ open class AirMapStatusAdvisory: Hashable, Equatable {
 		}
 	}
 	
-	open var hashValue: Int {
+	open override var hashValue: Int {
 		return id.hashValue
 	}
 	
-	open func isEqual(_ object: Any?) -> Bool {
+	open override func isEqual(_ object: Any?) -> Bool {
 		if let object = object as? AirMapStatusAdvisory {
 			return object.id == self.id
 		} else {

--- a/Source/Core/Models/Status/AirMapStatusWeather.swift
+++ b/Source/Core/Models/Status/AirMapStatusWeather.swift
@@ -8,7 +8,7 @@
 
 import ObjectMapper
 
-open class AirMapStatusWeather {
+open class AirMapStatusWeather : NSObject {
 
 	open var condition: String!
 	open var wind: AirMapStatusWeatherWind!

--- a/Source/Core/Models/Status/AirMapStatusWeatherWind.swift
+++ b/Source/Core/Models/Status/AirMapStatusWeatherWind.swift
@@ -8,7 +8,7 @@
 
 import ObjectMapper
 
-open class AirMapStatusWeatherWind {
+open class AirMapStatusWeatherWind : NSObject {
 	
 	open var heading: Int = 0
 	open var speed: Int = 0 // km/h


### PR DESCRIPTION
This allows the AirMapStatus class to be used in projects that are mainly using Objective-C.  The changes were very superficial other than creating a shadow enum that mirrors the AirMapStatus.StatusColor string enum.