### PR TITLE
Added icao to advisory's airport and heliport properties

### DIFF
--- a/Source/Core/Models/Advisory/AirMapAdvisory.swift
+++ b/Source/Core/Models/Advisory/AirMapAdvisory.swift
@@ -78,6 +78,7 @@ extension AirMapAdvisory {
 		public let instrumentProcedure: Bool?
 		public let url: URL?
 		public let description: String?
+		public let icao: String?
 	}
 	
 	/// AMA field properties
@@ -97,6 +98,7 @@ extension AirMapAdvisory {
 		public let tower: Bool?
 		public let use: String?
 		public let instrumentProcedure: Bool?
+		public let icao: String?
 	}
 	
 	/// Controlled Airspace advisory properties

--- a/Source/Core/Models/JSONSerialization.swift
+++ b/Source/Core/Models/JSONSerialization.swift
@@ -132,6 +132,7 @@ extension AirMapAdvisory.AirportProperties: ImmutableMappable {
 		              =  try? map.value("instrument_approach_procedure")
 		url           =  try? map.value("url", using: URLTransform())
 		description   =  try? map.value("description")
+		icao          =  try? map.value("icao")
 	}
 }
 	
@@ -205,6 +206,7 @@ extension AirMapAdvisory.HeliportProperties: ImmutableMappable {
 		use           =  try? map.value("use")
 		instrumentProcedure
 			=  try? map.value("instrument_approach_procedure")
+		icao          =  try? map.value("icao")
 	}
 }
 


### PR DESCRIPTION
Hello. It will be very helpful, if you add icao property to advisory's AirportProperties and HeliportProperties. It is only four strings of code, it will not affect current AirMapSDK users. It comes from backend and it was in the previous versions of AirMapSDK, but now we lose it.