### PR TITLE
Fixed crash when using custom AirMapConfiguration

### DIFF
--- a/Source/Core/AirMap.swift
+++ b/Source/Core/AirMap.swift
@@ -10,11 +10,20 @@ import Foundation
 
 /// The `AirMap` class encapsulates all platform interactions for Rules, Advisories, Flight, Pilot, and more.
 public class AirMap {
-	
-	/// The current environment settings and configuration of the AirMap SDK. May be set explicity or will be loaded from a provided airmap.config.json file.
-	public static var configuration: AirMapConfiguration = {
-		return AirMapConfiguration.defaultConfig()
-	}()
-	
+
+    /// Manually added configuration
+    static var customConfiguration: AirMapConfiguration?
+
+    /// The current environment settings and configuration of the AirMap SDK. May be set explicity or will be loaded from a provided airmap.config.json file.
+	public static var configuration: AirMapConfiguration {
+        get {
+            return customConfiguration ?? AirMapConfiguration.defaultConfig()
+        }
+
+        set {
+            customConfiguration = newValue
+        }
+    }
+
 	private init() {}
 }


### PR DESCRIPTION
Hello @adolfo . You added the ability to initialize the AirMapConfiguration object:
```
AirMap.configuration = AirMapConfiguration(
    apiKey: airmapApiKey,
    auth0ClientId: auth0ClientId,
    mapboxAccessToken: mapboxAccessToken
)
```
 But by default it was still called defaultConfig(), which caused an crash if the project did not contain 'airmap.config.json'.


P.S. Most projects get all the settings in environment variables, so using a text file with settings is a very inconvenient solution.