### PR TITLE
Fixed crash when TFRProperties don't contains url

### DIFF
--- a/Source/Core/Models/JSONSerialization.swift
+++ b/Source/Core/Models/JSONSerialization.swift
@@ -256,7 +256,7 @@ extension AirMapAdvisory.SpecialUseProperties: ImmutableMappable {
 extension AirMapAdvisory.TFRProperties: ImmutableMappable {
 	
 	public init(map: Map) throws {
-		url        =  try  map.value("url", using: URLTransform())
+		url        =  try? map.value("url", using: URLTransform())
 		startTime  =  try? map.value("effective_start", using: Constants.Api.dateTransform)
 		endTime    =  try? map.value("effective_end", using: Constants.Api.dateTransform)
 		type       =  try? map.value("type")


### PR DESCRIPTION
ObjectMapper crashes when trying to parse the following JSON
```
{
	"status": "success",
	"data": {
		"color": "red",
		"advisories": [{
			"id": "739e2ef0-006c-49cd-a481-155d096023e8",
			"name": "Osnova Intl",
			"last_updated": "2019-02-19T23:54:30.000Z",
			"latitude": 49.9269447,
			"longitude": 36.29,
			"distance": 0,
			"type": "airport",
			"city": "",
			"state": "Харківська",
			"country": "UKR",
			"rule_id": 4681,
			"ruleset_id": "ukr_airmap_rules",
			"properties": {
				"iata": "HRK",
				"icao": "UKHH",
				"paved": true,
				"phone": "+380577755418",
				"tower": true,
				"runways": [{
					"name": "07",
					"length": 2500,
					"true_bearing": 82.73,
					"runway_threshold_latitude": 49.92545,
					"runway_threshold_longitude": 36.2734889
				}, {
					"name": "25",
					"length": 2500,
					"true_bearing": 262.76,
					"runway_threshold_latitude": 49.9282889,
					"runway_threshold_longitude": 36.3080222
				}],
				"helipads": [{
					"name": "3",
					"latitude": "49.9205555555556",
					"longitude": "36.2638888888889",
					"HelipadDbId": "24871"
				}, {
					"name": "1",
					"latitude": "49.9259888888889",
					"longitude": "36.3004694444444",
					"HelipadDbId": "24872"
				}],
				"elevation": 529,
				"longest_runway": 2500,
				"instrument_approach_procedure": true,
				"type": "public",
				"use": "public"
			},
			"color": "yellow",
			"requirements": {
				"notice": {
					"phone": "+380577755418",
					"digital": false
				}
			}
		}, {
			"id": "5f84e221-9d97-4844-bbee-9de94239587c",
			"name": "Sokol'nyky",
			"last_updated": "2019-02-19T23:54:30.000Z",
			"latitude": 50.0250002,
			"longitude": 36.267222,
			"distance": 0,
			"type": "airport",
			"city": "",
			"state": "Харківська",
			"country": "UKR",
			"rule_id": 4681,
			"ruleset_id": "ukr_airmap_rules",
			"properties": {
				"icao": "UKHD",
				"paved": true,
				"phone": "+380577003439",
				"tower": true,
				"runways": [{
					"name": "02",
					"length": 1800,
					"true_bearing": 32.47,
					"runway_threshold_latitude": 50.0183028,
					"runway_threshold_longitude": 36.2605861
				}, {
					"name": "20",
					"length": 1800,
					"true_bearing": 212.48,
					"runway_threshold_latitude": 50.0319444,
					"runway_threshold_longitude": 36.2741028
				}],
				"elevation": 592,
				"longest_runway": 1800,
				"instrument_approach_procedure": true,
				"type": "public",
				"use": "public"
			},
			"color": "yellow",
			"requirements": {
				"notice": {
					"phone": "+380577003439",
					"digital": false
				}
			}
		}, {
			"id": "123893d5-9d8e-4ced-ac07-6cd99a5f83d9",
			"name": "UKHH (KHARKIV CTR)",
			"last_updated": "2019-02-24T20:08:36.000Z",
			"latitude": 49.9518365,
			"longitude": 36.3045315,
			"distance": 0,
			"type": "controlled_airspace",
			"city": null,
			"state": "Харківська",
			"country": "UKR",
			"rule_id": 4688,
			"ruleset_id": "ukr_airmap_rules",
			"properties": {
				"type": "d"
			},
			"color": "yellow",
			"requirements": {
				"notice": {
					"phone": null,
					"digital": false
				}
			}
		}, {
			"id": "bfca52d7-a9c4-4463-a59d-52898e3d5d5a",
			"name": "UKHD (KHARKIV CTR)",
			"last_updated": "2019-02-24T20:08:36.000Z",
			"latitude": 50.1083344,
			"longitude": 36.2000001,
			"distance": 0,
			"type": "controlled_airspace",
			"city": null,
			"state": null,
			"country": "UKR",
			"rule_id": 4688,
			"ruleset_id": "ukr_airmap_rules",
			"properties": {
				"type": "d"
			},
			"color": "yellow",
			"requirements": {
				"notice": {
					"phone": null,
					"digital": false
				}
			}
		}, {
			"id": "231700a9-8555-499a-ac1e-b7c891f69d42",
			"name": "Shakhtar vs. Oleksandriya",
			"last_updated": "2019-02-25T13:30:52.000Z",
			"latitude": 49.9808581,
			"longitude": 36.2617038,
			"distance": 0,
			"type": "tfr",
			"city": "Kharkiv",
			"state": "Харківська",
			"country": "UKR",
			"rule_id": 4686,
			"ruleset_id": "ukr_airmap_rules",
			"properties": {
				"type": "sport",
				"sport": "soccer",
				"venue_name": "Metalist Stadium",
				"effective_start": "2019-02-25T16:00:00.000Z",
				"effective_end": "2019-02-25T20:00:00.000Z"
			},
			"color": "red",
			"requirements": {
				"notice": {
					"phone": null,
					"digital": false
				}
			}
		}]
	}
}
```