### PR TITLE
Fix for MS-759 ‘Upon Submission’ => ‘Pending Submission’

### DIFF
--- a/Resources/Core/Localizations/en.lproj/Localizable.strings
+++ b/Resources/Core/Localizations/en.lproj/Localizable.strings
@@ -176,7 +176,7 @@
 "AUTHORIZATION_REJECTED_UPON_SUBMISSION" = "Rejected Upon Submission";
 
 /* The request with the authority will be accepted once the flight plan is submitted */
-"AUTHORIZATION_UPON_SUBMISSION" = "Authorization Upon Submission";
+"AUTHORIZATION_UPON_SUBMISSION" = "Authorization Pending Submission";
 
 /* Login message when a user's account has been blacklisted. */
 "AUTH_ERROR_ACCOUNT_BLACKLISTED" = "Your account has been blacklisted. Please contact security@airmap.com";

--- a/Source/Core/LocalizedStrings.swift
+++ b/Source/Core/LocalizedStrings.swift
@@ -39,7 +39,7 @@ public struct LocalizedStrings {
 		
 		public static let accepted = NSLocalizedString("AUTHORIZATION_ACCEPTED", bundle: bundle, value: "Approved", comment: "The request with the authority has been accepted")
 		
-		public static let authorizedUponSubmission = NSLocalizedString("AUTHORIZATION_UPON_SUBMISSION", bundle: bundle, value: "Authorization Upon Submission", comment: "The request with the authority will be accepted once the flight plan is submitted")
+		public static let authorizedUponSubmission = NSLocalizedString("AUTHORIZATION_UPON_SUBMISSION", bundle: bundle, value: "Authorization Pending Submission", comment: "The request with the authority will be accepted once the flight plan is submitted")
 		
 		public static let notRequested = NSLocalizedString("AUTHORIZATION_NOT_REQUESTED", bundle: bundle, value: "Authorization Not Requested", comment: "The request with the authority has not been requested")
 		


### PR DESCRIPTION
This is required for FlightBriefing to change ‘Authorization Upon Submission’ to ‘Authorization Pending Submission’